### PR TITLE
Support referencing the repository root using {{repository}} in externals.

### DIFF
--- a/dotfiles/core.py
+++ b/dotfiles/core.py
@@ -97,9 +97,12 @@ class Dotfiles(object):
 
         for dotfile in self.externals.keys():
             self.dotfiles.append(Dotfile(dotfile,
-                os.path.expanduser(self.externals[dotfile]),
+                os.path.expanduser(self._expandvars(self.externals[dotfile])),
                 self.homedir))
 
+    def _expandvars(self, s):        
+        """Expand application/configuration defined variables."""
+        return s.replace("{{repository}}", self.repository)
     def _fqpn(self, dotfile):
         """Return the fully qualified path to a dotfile."""
 


### PR DESCRIPTION
What do you think of this...

This is my use case: 

The whole of ~/.m2 should not be synced, I wanted only .m2/settings.xml to be synced.

The resulting dotfilesrc:

[dotfiles]
ignore = [
    '.git',
    '.m2',
    'README']
externals = {
    '.m2/settings.xml': '{{repository}}/.m2/settings.xml' }

If you like this (or have a better idea) I will write documentation and all that stuff and append it to my feature branch,
