### PR TITLE
Add -M option to allow recusive merge of dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,64 @@
-*.pyc
-*.pyo
+### Python ###
+# Byte-compiled / optimized / DLL files
 __pycache__/
-.venv/
-.tox/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
 build/
+develop-eggs/
 dist/
-dotfiles.egg-info/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+
+### vim ###
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~

--- a/dotfiles/cli.py
+++ b/dotfiles/cli.py
@@ -64,6 +64,10 @@ def add_global_flags(parser):
                       action="store_true", dest="force", default=False,
                       help="overwrite colliding dotfiles (use with --sync)")
 
+    parser.add_option("-M", "--merge",
+                      action="store_true", dest="merge", default=False,
+                      help="recursively merge dotfiles (use with --sync)")
+
     parser.add_option("-R", "--repo",
                       type="string", dest="repository",
                       help="set repository location (default: %s)" % (
@@ -179,7 +183,8 @@ def dispatch(repo, opts, args):
         getattr(repo, opts.action)(args)
 
     elif opts.action == 'sync':
-        getattr(repo, opts.action)(files=args, force=opts.force)
+        getattr(repo, opts.action)(
+            files=args, force=opts.force, merge=opts.merge)
 
     elif opts.action == 'move':
         if len(args) > 1:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -62,16 +62,20 @@ class DotfilesTestCase(unittest.TestCase):
                 '/tmp')
 
     def test_dispatch(self):
-        """Test that the force option is handed on to the sync method."""
+        """
+        Test that the force and merge option is handed on to the sync method.
+        """
 
         class MockDotfiles(object):
-            def sync(self, files=None, force=False):
+            def sync(self, files=None, force=False, merge=False):
                 assert force
+                assert merge
 
         class MockNamespace(object):
             def __init__(self):
                 self.action = 'sync'
                 self.force = True
+                self.merge = True
 
         dispatch(MockDotfiles(), MockNamespace(), [])
 


### PR DESCRIPTION
This allows files to be tracked using dotfiles that live in default dot-directories, e.g. .local and .config. Force works as expected. If there is a conflict during recursion it will skip the file unless force is specified.
