### PR TITLE
Expands ~'s in config file path

### DIFF
--- a/dotfiles/cli.py
+++ b/dotfiles/cli.py
@@ -143,9 +143,8 @@ def parse_args():
 
 
 def parse_config(config_file):
-
     parser = configparser.SafeConfigParser()
-    parser.read(config_file)
+    parser.read(os.path.expanduser(config_file))
 
     opts = dict()
 


### PR DESCRIPTION
Without this the default config file path, or any path that uses ~'s, doesn't work.

I believe this will fix issue #34
